### PR TITLE
Enable debug symbols in fastbuild mode

### DIFF
--- a/cpp/CROSSTOOL
+++ b/cpp/CROSSTOOL
@@ -76,6 +76,7 @@ toolchain {
 
   compilation_mode_flags {
     mode: FASTBUILD
+    compiler_flag: "-g"
   }
 
   compilation_mode_flags {


### PR DESCRIPTION
Since we turn on optimizations in debug mode, we do not have a build mode that enables debug symbols without any optimizations. Optimizations make debugging difficult, since they consolidate codepaths and remove abstraction layers (like, functions). With this change, we can use the fastbuild mode to get debugging symbols without optimizations.